### PR TITLE
using different sendfd to support arm architectures

### DIFF
--- a/recon_linux.go
+++ b/recon_linux.go
@@ -1,7 +1,7 @@
 package hbot
 
 import (
-	"bitbucket.org/madmo/sendfd"
+	"github.com/mudler/sendfd"
 	"fmt"
 	"net"
 )


### PR DESCRIPTION
Hi again,

While i was trying to cross-compile the bot on armv5, i had an error with sendfd (wasn't supported by it)
so i forked the original sendfd (https://bitbucket.org/madmo/sendfd) to enable support for arm architecture, in this way it's compilable on arm v5/6/7/whatever :)

Cheers