### PR TITLE
Update irc.unixastr in hellabot.go to allow for multiple bots with the same nick to different servers

### DIFF
--- a/hellabot.go
+++ b/hellabot.go
@@ -121,7 +121,7 @@ func NewIrcConnection(host, nick string, ssl, recon bool) (*IrcCon, error) {
 	irc.outgoing = make(chan string, 16)
 	irc.Channels = make(map[string]*IrcChannel)
 	irc.nick = nick
-	irc.unixastr = fmt.Sprintf("@%s/irc", nick)
+	irc.unixastr = fmt.Sprintf("@%s-%s/irc", host, nick)
 	irc.UseSSL = ssl
 	irc.ThrottleDelay = time.Millisecond * 200
 


### PR DESCRIPTION
This allows us to have more of the same bot connected to multiple networks without there being a problem. :)