### PR TITLE
Update hellabot.Msg to just return if the message is empty

### DIFF
--- a/hellabot.go
+++ b/hellabot.go
@@ -279,6 +279,10 @@ func (irc *IrcCon) Start() {
 
 // Send a message to 'who' (user or channel)
 func (irc *IrcCon) Msg(who, text string) {
+	// if len(text) == 0, return instead of trying to send a empty message
+	if len(text) == 0 {
+		return
+	}
 	for len(text) > 400 {
 		irc.Send("PRIVMSG " + who + " :" + text[:400])
 		text = text[400:]


### PR DESCRIPTION
This way we avoid the 412 No text to send errors.

`&{0xc208448660 No text to send 412 [ybot] 2015-08-07 11:50:09.296674234 +0200 CEST ybot stark.coldfront.net :stark.coldfront.net 412 ybot :No text to send}`