### PR TITLE
Update import statement for sorcix/irc to use gopkg.in

### DIFF
--- a/hellabot.go
+++ b/hellabot.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sorcix/irc"
+	"gopkg.in/sorcix/irc.v1"
 	log "gopkg.in/inconshreveable/log15.v2"
 	logext "gopkg.in/inconshreveable/log15.v2/ext"
 


### PR DESCRIPTION
The IRC library uses `internal` packages, which break when vendoring/sourcing from the Github URL as opposed to Gopkg.in

This PR updates the import namespace so that the `internal` imports work when using vendoring strategies.