### PR TITLE
Fix SASL auth error.

### DIFF
--- a/hellabot.go
+++ b/hellabot.go
@@ -149,7 +149,7 @@ func (bot *Bot) SASLAuthenticate(user, pass string) {
 	bot.sendUserCommand(bot.Nick, bot.Nick, "8")
 
 	bot.WaitFor(func(mes *Message) bool {
-		return mes.Content == "sasl" && len(mes.Params) > 1 && mes.Params[1] == "ACK"
+		return strings.TrimSpace(mes.Content) == "sasl" && len(mes.Params) > 1 && mes.Params[1] == "ACK"
 	})
 	bot.Debug("Recieved SASL ACK")
 	bot.Send("AUTHENTICATE PLAIN")


### PR DESCRIPTION
Freenode was returning `sasl ` instead of `sasl` (note the different trailing whitespace), which was causing an issue with the WaitFor. Tested against the MCV example provided; this should close #33.