### PR TITLE
Handle SASL authentication with a trigger

### DIFF
--- a/hellabot.go
+++ b/hellabot.go
@@ -186,6 +186,16 @@ func (bot *Bot) SASLAuthenticate(user, pass string) {
 	bot.sendUserCommand(bot.Nick, bot.Nick, "8")
 }
 
+// WaitFor will block until a message matching the given filter is received
+func (bot *Bot) WaitFor(filter func(*Message) bool) {
+	for mes := range bot.Incoming {
+		if filter(mes) {
+			return
+		}
+	}
+	return
+}
+
 // StandardRegistration performsa a basic set of registration commands
 func (bot *Bot) StandardRegistration() {
 	//Server registration

--- a/hellabot.go
+++ b/hellabot.go
@@ -156,38 +156,34 @@ func (bot *Bot) handleOutgoingMessages() {
 // SASLAuthenticate performs SASL authentication
 // ref: https://github.com/atheme/charybdis/blob/master/doc/sasl.txt
 func (bot *Bot) SASLAuthenticate(user, pass string) {
+	var saslHandler = Trigger{
+		Condition: func(bot *Bot, m *Message) bool {
+			return (strings.TrimSpace(m.Content) == "sasl" && len(m.Params) > 1 && m.Params[1] == "ACK") ||
+				(m.Command == "AUTHENTICATE" && len(m.Params) == 1 && m.Params[0] == "+")
+		},
+		Action: func(bot *Bot, m *Message) bool {
+			if strings.TrimSpace(m.Content) == "sasl" && len(m.Params) > 1 && m.Params[1] == "ACK" {
+				bot.Debug("Recieved SASL ACK")
+				bot.Send("AUTHENTICATE PLAIN")
+			}
+
+			if m.Command == "AUTHENTICATE" && len(m.Params) == 1 && m.Params[0] == "+" {
+				bot.Debug("Got auth message!")
+				out := bytes.Join([][]byte{[]byte(user), []byte(user), []byte(pass)}, []byte{0})
+				encpass := base64.StdEncoding.EncodeToString(out)
+				bot.Send("AUTHENTICATE " + encpass)
+				bot.Send("AUTHENTICATE +")
+				bot.Send("CAP END")
+			}
+			return false
+		},
+	}
+
+	bot.AddTrigger(saslHandler)
 	bot.Debug("Beginning SASL Authentication")
 	bot.Send("CAP REQ :sasl")
 	bot.SetNick(bot.Nick)
 	bot.sendUserCommand(bot.Nick, bot.Nick, "8")
-
-	bot.WaitFor(func(mes *Message) bool {
-		return strings.TrimSpace(mes.Content) == "sasl" && len(mes.Params) > 1 && mes.Params[1] == "ACK"
-	})
-	bot.Debug("Recieved SASL ACK")
-	bot.Send("AUTHENTICATE PLAIN")
-
-	bot.WaitFor(func(mes *Message) bool {
-		return mes.Command == "AUTHENTICATE" && len(mes.Params) == 1 && mes.Params[0] == "+"
-	})
-
-	bot.Debug("Got auth message!")
-
-	out := bytes.Join([][]byte{[]byte(user), []byte(user), []byte(pass)}, []byte{0})
-	encpass := base64.StdEncoding.EncodeToString(out)
-	bot.Send("AUTHENTICATE " + encpass)
-	bot.Send("AUTHENTICATE +")
-	bot.Send("CAP END")
-}
-
-// WaitFor will block until a message matching the given filter is received
-func (bot *Bot) WaitFor(filter func(*Message) bool) {
-	for mes := range bot.Incoming {
-		if filter(mes) {
-			return
-		}
-	}
-	return
 }
 
 // StandardRegistration performsa a basic set of registration commands


### PR DESCRIPTION
* Handle SASL authentication with a trigger

* Remove the WaitFor method as it can't be used outside the SASL authentication function. Using it in triggers causes 'Incoming chan *Message' have multiple readers