### PR TITLE
Retrieve and store the bot's own Prefix and use it to do correct text splitting

### DIFF
--- a/recon_linux.go
+++ b/recon_linux.go
@@ -2,9 +2,12 @@ package hbot
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 
 	"github.com/ftrvxmtrx/fd"
+	"gopkg.in/sorcix/irc.v1"
 )
 
 // StartUnixListener starts up a unix domain socket listener for reconnects to
@@ -39,6 +42,12 @@ func (bot *Bot) StartUnixListener() {
 		panic(err)
 	}
 
+	// Send our prefix
+	_, err = io.WriteString(con, bot.Prefix.String())
+	if err != nil {
+		panic(err)
+	}
+
 	select {
 	case <-bot.Incoming:
 	default:
@@ -66,6 +75,14 @@ func (bot *Bot) hijackSession() bool {
 	if err != nil {
 		panic(err)
 	}
+
+	// Read the reminder which should be our prefix
+	prefix, err := ioutil.ReadAll(con)
+	if err != nil {
+		panic(err)
+	}
+	bot.Prefix = irc.ParsePrefix(string(prefix))
+
 	bot.reconnecting = true
 	bot.con = netcon
 	return true

--- a/recon_unix.go
+++ b/recon_unix.go
@@ -4,10 +4,13 @@ package hbot
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"syscall"
 
 	"github.com/ftrvxmtrx/fd"
+	"gopkg.in/sorcix/irc.v1"
 )
 
 // StartUnixListener starts up a unix domain socket listener for reconnects to
@@ -46,6 +49,12 @@ func (bot *Bot) StartUnixListener() {
 		panic(err)
 	}
 
+	// Send our prefix
+	_, err = io.WriteString(con, bot.Prefix.String())
+	if err != nil {
+		panic(err)
+	}
+
 	select {
 	case <-bot.Incoming:
 	default:
@@ -73,6 +82,14 @@ func (bot *Bot) hijackSession() bool {
 	if err != nil {
 		panic(err)
 	}
+
+	// Read the reminder which should be our prefix
+	prefix, err := ioutil.ReadAll(con)
+	if err != nil {
+		panic(err)
+	}
+	bot.Prefix = irc.ParsePrefix(string(prefix))
+
 	bot.reconnecting = true
 	bot.con = netcon
 	return true


### PR DESCRIPTION
* Store the bot's own prefix in the *Bot struct

* It is exported field, it could be useful in some custom logic

* Read the Prefix from the bot's own JOIN message using the getPrefix trigger. If we are joining multiple channels it will only fire once (didGetPrefix sync.Once)

* If we can't get the prefix for some strange reason, NewBot() will initialize Prefix with sane values

* SetNick() will also adjust bot.Prefix.Name

* Prefix is forwarded over the UNIX socket if we are doing session hijacking, because we loose state

* splitText() now splits lines according to maximally allowed size as defined by the IRC specification which is 512 bytes. It also does UTF-8 aware splitting to avoid splitting runes (which can be up to 4 bytes long). To do this it needs 3 more arguments: command, who and Prefix.

* Msg() and Notice() have been changed accordingly