### PR TITLE
fix: log incoming message scanner errors

### DIFF
--- a/hellabot.go
+++ b/hellabot.go
@@ -145,6 +145,11 @@ func (bot *Bot) handleIncomingMessages() {
 		}()
 		bot.Incoming <- msg
 	}
+
+	if err := scan.Err(); err != nil {
+		bot.Crit("bot.handleIncomingMessages error", "err", err.Error())
+	}
+
 	close(bot.Incoming)
 }
 


### PR DESCRIPTION
Related: https://github.com/whyrusleeping/hellabot/issues/67

This PR will log errors from the bufio scanner which is used for incoming irc messages.

This will produce a error that is currently hidden from the library:

```
bot_1           | t=2022-07-11T18:18:59+0000 lvl=crit msg="bot.handleIncomingMessages error" id=447de9f0374d1b7a host=my.bouncer:6697 nick=mynick err="read tcp 172.19.0.8:36084->172.19.0.5:6697: i/o timeout"
```