### PR TITLE
Use bot.Nick and bot.Realname when doing SASL authenticate

### DIFF
--- a/sasl.go
+++ b/sasl.go
@@ -65,5 +65,5 @@ func (bot *Bot) SASLAuthenticate(user, pass string) {
 	bot.Debug("Beginning SASL Authentication")
 	bot.Send("CAP REQ :sasl")
 	bot.SetNick(bot.Nick)
-	bot.sendUserCommand(bot.Nick, bot.Nick)
+	bot.sendUserCommand(bot.Nick, bot.Realname)
 }


### PR DESCRIPTION
hellabot is setting the wrong realname when performing SASL auth in `SASLAuthentictae()`
https://github.com/whyrusleeping/hellabot/blob/98cbebb8a5a9f9496378fef27b88fb41fe81ca80/sasl.go#L62-L69

Seems like a mistake and `bot.sendUserCommand(bot.Nick, bot.Realname)` was intended.